### PR TITLE
Unittests fuer Funktion DistanceInMeters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,16 @@ project(geostuff)
 
 set(CMAKE_BUILD_TYPE Release)
 
+INCLUDE_DIRECTORIES(
+	libs/gtest-1.7.0/include
+	libs/gtest-1.7.0
+	libs/sqlite-amalgamation-3081002
+)
+
+add_subdirectory(src)
+
+
+
 add_executable(distancefromlatlonglatlong
 	src/GPSObservation.cpp
 	src/GPSObservation.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(tests)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(tests
+#DUTs:
+	../GPSObservation.cpp
+	../GPSObservation.hpp
+#Unittests:
+	GPSObservationTests.cpp
+#Hauptprogramm:
+	../../libs/gtest-1.7.0/src/gtest-all.cc
+    TestsMain.cpp
+
+)
+

--- a/src/tests/GPSObservationTests.cpp
+++ b/src/tests/GPSObservationTests.cpp
@@ -1,0 +1,35 @@
+// Datei: GPSObservationTests.cpp
+//
+// Unittests für ./src/GPSObservation.hpp/cpp
+
+// DUT:
+#include "../GPSObservation.hpp"
+
+
+// Google Test Library:
+#include "gtest/gtest.h"
+
+
+TEST(GPSObservationTests, DinstanceInMeters)
+{
+	GPSObservation goBochum(51.4818445, 7.2162363);
+	GPSObservation goDortmund(51.5135872, 7.4652981);
+	GPSObservation goRecklinghausen(51.6140649, 7.1979453);
+	GPSObservation goHirtshals(57.588120, 9.959220);
+
+	double dBochumDortmund = DinstanceInMeters(goBochum, goDortmund);
+	double dDortmundBochum = DinstanceInMeters(goDortmund, goBochum);
+
+	ASSERT_NEAR(17598.6179, dBochumDortmund, 0.1);
+
+	ASSERT_NEAR(dDortmundBochum, dBochumDortmund, 0.001);
+
+	double dBochumRecklinghausen = DinstanceInMeters(goBochum, goRecklinghausen);
+	ASSERT_NEAR(14756.5393, dBochumRecklinghausen, 0.1);
+
+	double dBochumHirtshals = DinstanceInMeters(goBochum, goHirtshals);
+	ASSERT_NEAR(701520.6178, dBochumHirtshals, 0.1); 
+	// https://www.luftlinie.org/Hirtshals,Hj%C3%B8rring,Nordjylland,DNK/Bochum gibt 701.70 km an, wir errechnen 701.52km. 
+	// Ein Rechenfehler von 200m auf 700km ist gut genug für unser Hackprojekt
+
+}

--- a/src/tests/TestsMain.cpp
+++ b/src/tests/TestsMain.cpp
@@ -1,0 +1,14 @@
+// Datei TestsMain.cpp
+//
+// Einsprungpunkt. Hauptprogramm.
+
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int nErg = RUN_ALL_TESTS();
+  
+  return nErg;
+}

--- a/src/tools/distancefromlatlonglatlong.cpp
+++ b/src/tools/distancefromlatlonglatlong.cpp
@@ -24,11 +24,8 @@ int main(int argc, const char** argv)
 {
 	int nRet = 0;
 
-	GPSObservation p1(51.4818445, 7.2162363);// Bochum
-	GPSObservation p2(51.5135872, 7.4652981);// Dortmund
-
-//	51.4818445 7.2162363 51.5135872 7.4652981
-
+	GPSObservation p1;
+	GPSObservation p2;
 
 	bool bParsedProperly = ParseCommandLine(p1, p2, argc, argv);
 


### PR DESCRIPTION
Funktion DistanceInMeters mit Unittests abgedeckt für kurze Nord-Süd-Distanz und West-Ost-Distanz im Ruhrgebiet und einer größeren in Europa. 